### PR TITLE
Fix cleanup call after door trigger

### DIFF
--- a/garagedoorleft.py
+++ b/garagedoorleft.py
@@ -13,16 +13,17 @@ pinList = [2]
 
 # loop through pins and set mode and state to 'low'
 
-for i in pinList: 
-    GPIO.setup(i, GPIO.OUT) 
+for i in pinList:
+    GPIO.setup(i, GPIO.OUT)
     GPIO.output(i, GPIO.HIGH)
 
 def trigger() :
-        for i in pinList:
-          GPIO.output(i, GPIO.LOW)
-          time.sleep(0.5) 
-          GPIO.output(i, GPIO.HIGH)
-          GPIO.cleanup()
+    for i in pinList:
+        GPIO.output(i, GPIO.LOW)
+        time.sleep(0.5)
+        GPIO.output(i, GPIO.HIGH)
+
+    GPIO.cleanup()
      
 
 try: 

--- a/garagedoorright.py
+++ b/garagedoorright.py
@@ -18,11 +18,12 @@ for i in pinList:
     GPIO.output(i, GPIO.HIGH)
 
 def trigger() :
-        for i in pinList:
-          GPIO.output(i, GPIO.LOW)
-          time.sleep(0.5) 
-          GPIO.output(i, GPIO.HIGH)
-          GPIO.cleanup()
+    for i in pinList:
+        GPIO.output(i, GPIO.LOW)
+        time.sleep(0.5)
+        GPIO.output(i, GPIO.HIGH)
+
+    GPIO.cleanup()
      
 
 try: 


### PR DESCRIPTION
## Summary
- clean up GPIO pins outside of loop in door scripts

## Testing
- `python3 - <<'PY'
import RPi.GPIO
print('skip')
PY`

------
https://chatgpt.com/codex/tasks/task_e_685715dc187c8332a390b9db03e5526a